### PR TITLE
fix ssm launch so fast.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,5 @@ $ ./build.sh
 ```
 
 - [Ubuntu Amazon EC2 AMI Finder](https://cloud-images.ubuntu.com/locator/ec2/)
+
+Select a your region and version `16.04LTS`.

--- a/itamae/cookbooks/base/files/etc/systemd/system/amazon-ssm-agent.service
+++ b/itamae/cookbooks/base/files/etc/systemd/system/amazon-ssm-agent.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=amazon-ssm-agent
+After=network.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
To resolv this issue
http://qiita.com/wankoromaru/items/e2a60205d9222c74a316

And README .
`Non LTS` failed to build with packer, due to `grub-legacy-ec2`?